### PR TITLE
Add json parse option to request

### DIFF
--- a/forecast-io.js
+++ b/forecast-io.js
@@ -42,7 +42,7 @@ class ForecastIO {
         !lang ? null : this.query.lang = lang;
         return this;
     }
-    
+
     exclude(blocks){
         !blocks ? null : this.query.exclude = blocks;
         return this;
@@ -50,7 +50,7 @@ class ForecastIO {
 
     extendHourly(param){
         param ? this.query.extend = 'hourly' : null;
-        return this ;      
+        return this ;
     }
 
     generateReqUrl() {
@@ -59,10 +59,14 @@ class ForecastIO {
         this.query ? this.url += `?${queryString.stringify(this.query)}` : this.url;
     }
 
-    get() {
-        return new Promise((resolve, reject) => {
+	get() {
+		return new Promise((resolve, reject) => {
             this.generateReqUrl();
-            req(this.url, (err, res, body) => {
+			let options = {
+				url: this.url,
+				json: true
+			};
+			req(options, (err, res, body) => {
                 if(res.statusCode !== 200 || err){
                     reject(`Script Error: ${err} \nAPI Response: ${res.statusCode} :: ${res.statusMessage}`)
                 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forecast-io",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A dead simple forecast.io API wrapper for Nodejs using method chaining and promises.",
   "main": "forecast-io.js",
   "scripts": {


### PR DESCRIPTION
Changed the request so we can pass options. Added the `json: true` options so that the response is already parsed.