### PR TITLE
Use the drop-in replacement pirateweather API

### DIFF
--- a/dark-sky-api.js
+++ b/dark-sky-api.js
@@ -122,7 +122,7 @@ class DarkSky {
   }
 
   _generateReqUrl() {
-    this.url = `https://api.darksky.net/forecast/${this.apiKey}/${this.lat},${
+    this.url = `https://api.pirateweather.net/forecast/${this.apiKey}/${this.lat},${
       this.long
     }`
     if (this.timeVal) {


### PR DESCRIPTION
Pirate Weather is a free (donatable) drop-in replacement for the defunct Dark Sky API and your code already works great against it.
More info at https://docs.pirateweather.net/en/latest/API/
This would fix your #21 :)
If you would prefer a configurable base URL instead, let me know and I can revise the PR.

I hope you're well, and thanks so much for your efforts on this package!💜